### PR TITLE
Fix: URLs of shields in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # IdeaSwiftformat
 
 ![Build](https://github.com/dankinsoid/IdeaSwiftformat/workflows/Build/badge.svg)
-[![Version](https://img.shields.io/jetbrains/plugin/v/PLUGIN_ID.svg)](https://plugins.jetbrains.com/plugin/PLUGIN_ID)
-[![Downloads](https://img.shields.io/jetbrains/plugin/d/PLUGIN_ID.svg)](https://plugins.jetbrains.com/plugin/PLUGIN_ID)
+[![Version](https://img.shields.io/jetbrains/plugin/v/19571.svg)](https://plugins.jetbrains.com/plugin/19571)
+[![Downloads](https://img.shields.io/jetbrains/plugin/d/19571.svg)](https://plugins.jetbrains.com/plugin/19571)
 
 <!-- Plugin description -->
 This plugin provides integration with [`SwiftFormat`](https://github.com/nicklockwood/SwiftFormat).


### PR DESCRIPTION
README's URLs are broken and do not link to the page of the plugin.

This is a small PR to fix this.

On a side note, do you accept contributions ? 